### PR TITLE
Remove observers when erste component is disposed

### DIFF
--- a/lib/register.js
+++ b/lib/register.js
@@ -21,10 +21,17 @@ module.exports = observe => ({ Component }) => {
       this.constructor.prototype.__regie_changes__ = changes
     }
 
-    changes.forEach(([mapperProducer, handlerProducer]) => {
-      observe(mapperProducer(this), handlerProducer(this))
-    })
+    this.__regie_observer_removers__ = changes.map(([mapperProducer, handlerProducer]) =>
+      observe(mapperProducer(this), handlerProducer(this)))
+
+    originalHook && originalHook.call(this)
   }
 
-  originalHook && originalHook.call(this)
+  const originalDispose = Component.prototype.dispose
+
+  Component.prototype.dispose = function () {
+    this.__regie_observer_removers__.forEach(removeObserver => removeObserver())
+
+    originalDispose.call(this)
+  }
 }

--- a/test/register.js
+++ b/test/register.js
@@ -78,3 +78,64 @@ test.cb('Utilize magic observer method on a component and observe state change',
 
   state.val = val
 })
+
+test('__regie_observer_removers__ exists on initialized component', t => {
+  const { $$register, state } = regie({})
+
+  const val = Math.random()
+
+  class Component {
+    constructor (state) {
+      this.props = state
+
+      this.created()
+    }
+
+    created () {
+      this.createdHooks()
+    }
+
+    ['observe val'] (newValue) {
+      t.is(newValue, val)
+      t.end()
+    }
+  }
+
+  $$register({ Component })
+
+  const comp = new Component(state)
+
+  t.true(Array.isArray(comp.__regie_observer_removers__))
+})
+
+test.cb('Observers will not trigger handlers after component is disposed', t => {
+  const { $$register, state } = regie({})
+
+  class Component {
+    constructor (state) {
+      this.props = state
+
+      this.created()
+    }
+
+    created () {
+      this.createdHooks()
+    }
+
+    ['observe val'] () {
+      t.fail()
+    }
+
+    dispose () {}
+  }
+
+  $$register({ Component })
+
+  const comp = new Component(state)
+  comp.dispose()
+
+  state.val = Math.random()
+
+  t.pass()
+  t.end()
+})


### PR DESCRIPTION
This will add a private property with the array of observer remover functions to each component instance. Also erste plugin will tap into dispose method to  trigger removal of each observer created.

Without the disposal of observers, erste component will continue to call observer handler methods even after the component is disposed. It's a problem for reused components.
