### PR TITLE
V2

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,10 +1,12 @@
+/* eslint-disable no-new */
+
 const regie = require('.')
 
 const initialState = {
   navigation: {}
 }
 
-const { state, observe } = regie({ initialState })
+const { state, observe, $$register } = regie({ initialState }, { deep: true })
 
 observe('navigation.status.value', (newValue, change) => {
   console.log('ust', 'nv', newValue, 'c', change.newValue, '====')
@@ -16,3 +18,25 @@ observe('navigation.status', (newValue, change) => {
 
 state.navigation = { status: { value: 3 } }
 state.navigation = { status: { value: 10 } }
+
+class Component {
+  constructor () {
+    this.created()
+  }
+
+  created () {
+    this.createdHooks()
+  }
+
+  ['mapState navigation.status.value'] (newValue, change) {
+    console.log('yay', JSON.stringify(newValue))
+  }
+
+  dispose () { }
+}
+
+$$register({ Component })
+new Component()
+
+state.navigation = { status: { value: 5 } }
+state.navigation.status = { value: 3 }

--- a/example.js
+++ b/example.js
@@ -27,7 +27,8 @@ class Component {
 
   mapStateToProps () {
     return {
-      navStatus: state => state.navigation.status.value
+      stringValue: 'navigation.status.value',
+      methodValue: state => state.navigation.status.value
     }
   }
 
@@ -35,11 +36,13 @@ class Component {
     this.createdHooks()
   }
 
-  ['observe navStatus'] (newValue) {
-    console.log('observer', newValue)
+  ['observe stringValue'] (newValue, change) {
+    console.log('stringValue', newValue, change)
   }
 
-  dispose () { }
+  ['observe methodValue'] (newValue, change) {
+    console.log('methodValue', newValue, change)
+  }
 }
 
 $$register({ Component })

--- a/example.js
+++ b/example.js
@@ -1,58 +1,45 @@
-/* eslint-disable no-new */
-
-const regie = require('.')
-
-const initialState = {
-  navigation: {}
-}
-
-const { state, observe, $$register } = regie({ initialState }, { deep: true })
-
-observe('navigation.status.value', (newValue, change) => {
-  console.log('ust', 'nv', newValue, 'c', change.newValue, '====')
-})
-
-observe('navigation.status', (newValue, change) => {
-  console.log('alt', 'nv', newValue, 'c', change.newValue, '===')
-})
-
-state.navigation = { status: { value: 3 } }
-state.navigation = { status: { value: 10 } }
-
+const regie = require('./')
+const newVal = { location: [32, 5], battery: [10, 32], rid: 'hello' }
+const { $$register, state, actions } = regie(
+  {
+    initialState: { scooter: { location: [32, 45], battery: [10, 32], rid: 'hello' } },
+    actions: {
+      setScooter ({ mutations }, val) {
+        mutations.setVal(val)
+      }
+    },
+    mutations: {
+      setVal ({ state }, val) {
+        state.scooter = val
+      }
+    }
+  }, { deep: true })
 class Component {
   constructor (props) {
-    this.props = props
+    console.log('here are props', props)
+    this.props = props || {}
     this.created()
   }
-
-  mapStateToProps () {
-    return {
-      stringValue: 'navigation.status.value',
-      methodValue: state => state.navigation.status.value
-    }
-  }
-
   created () {
     this.createdHooks()
   }
-
-  ['observe stringValue'] (newValue, change) {
-    console.log('stringValue', newValue, change)
+  dispose () { }
+  ['observe scooter.location'] (location) {
+    console.log('scooter.location changed')
+    console.log(location, newVal.location)
+    // t.end()
   }
-
-  ['observe methodValue'] (newValue, change) {
-    console.log('methodValue', newValue, change)
+  ['observe scooter.rid'] () {
+    console.log('scooter.rid changed')
+    // t.fail()
+  }
+  ['observe scooter.battery'] () {
+    console.log('scooter.battery changed')
+    // t.fail()
   }
 }
-
 $$register({ Component })
-const comp = new Component({ hello: true })
-console.log(comp.props.navStatus)
-
-state.navigation = { status: { value: 7 } }
-console.log(comp.props.navStatus)
-
-state.navigation.status = { value: 3 }
-console.log(comp.props.navStatus)
-
-comp.props.navStatus = 11 // throws an error
+console.log('state', state)
+console.log('state', state.scooter)
+const cmp = new Component({ scooter: state.scooter })
+actions.setScooter(newVal)

--- a/example.js
+++ b/example.js
@@ -1,39 +1,18 @@
 const regie = require('.')
 
 const initialState = {
-  items: []
+  navigation: {}
 }
 
 const { state, observe } = regie({ initialState })
 
-const items = state.items
+observe('navigation.status.value', (newValue, change) => {
+  console.log('ust', 'nv', newValue, 'c', change.newValue, '====')
+})
 
-observe(() => items, (val) => console.log('updated items', val))
-observe(() => items[2].details, val => console.log('updated details', val))
+observe('navigation.status', (newValue, change) => {
+  console.log('alt', 'nv', newValue, 'c', change.newValue, '===')
+})
 
-const off = observe(() => items[2].details[2].name, val => console.log('off', val))
-
-items.push({ details: [{ name: 0 }, { name: 1 }] })
-items.push({ details: [{ name: 2 }, { name: 3 }] })
-items.push({ details: [{ name: 3 }, { name: 4 }] })
-
-let details = items[2].details
-const off2 = observe(() => details[2].name, val => console.log('off2', val))
-
-items[2].details = [{ name: 4 }, { name: 5 }]
-details = items[2].details
-
-details.push({ name: 10 })
-details.push({ name: 7 })
-details[2].name = 8
-details[2].name = 8
-details[2].name = 8
-details[2].name = 9
-details[2].name = 9
-off()
-details[2].name = 10
-details[2].name = 10
-details[2].name = 10
-details[2].name = 11
-off2()
-details[2].name = 12
+state.navigation = { status: { value: 3 } }
+state.navigation = { status: { value: 10 } }

--- a/example.js
+++ b/example.js
@@ -20,23 +20,36 @@ state.navigation = { status: { value: 3 } }
 state.navigation = { status: { value: 10 } }
 
 class Component {
-  constructor () {
+  constructor (props) {
+    this.props = props
     this.created()
+  }
+
+  mapStateToProps () {
+    return {
+      navStatus: state => state.navigation.status.value
+    }
   }
 
   created () {
     this.createdHooks()
   }
 
-  ['mapState navigation.status.value'] (newValue, change) {
-    console.log('yay', JSON.stringify(newValue))
+  ['observe navStatus'] (newValue) {
+    console.log('observer', newValue)
   }
 
   dispose () { }
 }
 
 $$register({ Component })
-new Component()
+const comp = new Component({ hello: true })
+console.log(comp.props.navStatus)
 
-state.navigation = { status: { value: 5 } }
+state.navigation = { status: { value: 7 } }
+console.log(comp.props.navStatus)
+
 state.navigation.status = { value: 3 }
+console.log(comp.props.navStatus)
+
+comp.props.navStatus = 11 // throws an error

--- a/example.js
+++ b/example.js
@@ -42,4 +42,6 @@ $$register({ Component })
 console.log('state', state)
 console.log('state', state.scooter)
 const cmp = new Component({ scooter: state.scooter })
+
+console.log(cmp.props.scooter)
 actions.setScooter(newVal)

--- a/index.js
+++ b/index.js
@@ -41,14 +41,15 @@ module.exports = ({ initialState = {}, actions = {}, mutations = {} } = {}, { de
         const path = val.__getPath || mapper.path
         if (deep && mapper.lastValue == val ? !isEqual(mapper.lastValue, val) : mapper.lastValue != val) {
           handler(val, change)
+          mapper.lastValue = val
         } else if (path && (change.currentPath.startsWith(path) || mapper.path.startsWith(change.currentPath)) && ((deep && change.newValue == change.previousValue) ? !isEqual(change.newValue, change.previousValue) : change.newValue != change.previousValue)) {
           handler(val, change)
+          mapper.lastValue = val
         } else if (path && (!change.currentPath.startsWith(path) && !path.startsWith(change.currentPath))) return
         else if (get(state, change.currentPath) == val) {
           handler(val, change)
+          mapper.lastValue = val
         }
-
-        mapper.lastValue = val
       } else if (typeof mapper.lastValue != 'undefined' && typeof val == 'undefined') {
         handler(undefined, change)
         mapper.lastValue = undefined

--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@ const EventEmitter = require('events')
 const get = require('lodash.get')
 const isEqual = require('lodash.isequal')
 const register = require('./lib/register')
-const isPrimitive = require('is-primitive')
 
 module.exports = ({ initialState = {}, actions = {}, mutations = {} } = {}, { deep } = { deep: false }) => {
   const bus = new EventEmitter()

--- a/index.js
+++ b/index.js
@@ -40,17 +40,17 @@ module.exports = ({ initialState = {}, actions = {}, mutations = {} } = {}, { de
 
         if (deep) {
           if (!isEqual(mapper.lastValue, val)) {
-            handler(val, change)
             mapper.lastValue = val
+            handler(val, change)
           }
         } else {
           if (mapper.lastValue != val) {
-            handler(val, change)
             mapper.lastValue = val
+            handler(val, change)
           } else {
             if ((change.currentPath.startsWith(path) || mapper.path.startsWith(change.currentPath)) && change.newValue != change.previousValue) {
-              handler(val, change)
               mapper.lastValue = val
+              handler(val, change)
             }
           }
         }

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ module.exports = ({ initialState = {}, actions = {}, mutations = {} } = {}, { de
       }
 
       if (typeof val != 'undefined') {
-        const path = val.__getPath || mapper.path
+        const path = (val && val.__getPath) || mapper.path
         const newValue = get(state, path)
         if (deep && mapper.lastValue == val ? !isEqual(mapper.lastValue, val) : mapper.lastValue != val) {
           handler(val, change)

--- a/index.js
+++ b/index.js
@@ -38,21 +38,9 @@ module.exports = ({ initialState = {}, actions = {}, mutations = {} } = {}, { de
       if (typeof val != 'undefined') {
         const path = (val && val.__getPath) || mapper.path
 
-        if (deep) {
-          if (!isEqual(mapper.lastValue, val)) {
-            mapper.lastValue = val
-            handler(val, change)
-          }
-        } else {
-          if (mapper.lastValue != val) {
-            mapper.lastValue = val
-            handler(val, change)
-          } else {
-            if ((change.currentPath.startsWith(path) || mapper.path.startsWith(change.currentPath)) && change.newValue != change.previousValue) {
-              mapper.lastValue = val
-              handler(val, change)
-            }
-          }
+        if (!isEqual(mapper.lastValue, val) || (change.currentPath.startsWith(path) && path.length <= change.currentPath.length)) {
+          mapper.lastValue = val
+          handler(val, change)
         }
       } else if (typeof mapper.lastValue != 'undefined' && typeof val == 'undefined') {
         handler(undefined, change)

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ module.exports = ({ initialState = {}, actions = {}, mutations = {} } = {}, { de
     return observeLater(mapperFn, handler)
   }
 
-  const boundRegister = register(observe)
+  const boundRegister = register(observe, state)
   const boundActions = {}
   const boundMutations = {}
 

--- a/index.js
+++ b/index.js
@@ -38,7 +38,10 @@ module.exports = ({ initialState = {}, actions = {}, mutations = {} } = {}, { de
       }
 
       if (typeof val != 'undefined') {
-        if (typeof mapper.lastValue == 'undefined' || deep ? !isEqual(mapper.lastValue, val) : mapper.lastValue != val || (val.__targetPosition && val.__targetPosition != value.__targetPosition)) {
+        if (typeof val.__getPath != 'undefined' && !change.currentPath.startsWith(val.__getPath)) return
+        else if (get(state, change.currentPath) == val) {
+          handler(val, change)
+        } else if (typeof mapper.lastValue == 'undefined' || deep ? !isEqual(mapper.lastValue, val) : mapper.lastValue != val || (val.__targetPosition && val.__targetPosition != value.__targetPosition)) {
           handler(val, change)
         }
 

--- a/index.js
+++ b/index.js
@@ -18,16 +18,6 @@ module.exports = ({ initialState = {}, actions = {}, mutations = {} } = {}, { de
 
       if (deep && isEqual(change.newValue, change.previousValue)) return
 
-      const paths = change.currentPath.split('.')
-      while (paths.length) {
-        const path = paths.join('.')
-        if (path in bus._events) {
-          bus.emit(path, get(state, path), change)
-        }
-
-        paths.pop()
-      }
-
       bus.emit('root', state, change)
     })
   })
@@ -48,7 +38,7 @@ module.exports = ({ initialState = {}, actions = {}, mutations = {} } = {}, { de
       }
 
       if (typeof val != 'undefined') {
-        if (typeof mapper.lastValue == 'undefined' || deep ? !isEqual(mapper.lastValue, val) : mapper.lastValue != val) {
+        if (typeof mapper.lastValue == 'undefined' || deep ? !isEqual(mapper.lastValue, val) : mapper.lastValue != val || (val.__targetPosition && val.__targetPosition != value.__targetPosition)) {
           handler(val, change)
         }
 
@@ -81,11 +71,6 @@ module.exports = ({ initialState = {}, actions = {}, mutations = {} } = {}, { de
     }
 
     mapperFn.lastValue = val
-
-    if (typeof val != 'undefined' && val.__getPath) {
-      bus.on(val.__getPath, handler)
-      return () => bus.removeListener(val.__getPath, handler)
-    }
 
     return observeLater(mapperFn, handler)
   }

--- a/index.js
+++ b/index.js
@@ -39,12 +39,13 @@ module.exports = ({ initialState = {}, actions = {}, mutations = {} } = {}, { de
 
       if (typeof val != 'undefined') {
         const path = val.__getPath || mapper.path
+        const newValue = get(state, path)
         if (deep && mapper.lastValue == val ? !isEqual(mapper.lastValue, val) : mapper.lastValue != val) {
           handler(val, change)
           mapper.lastValue = val
         } else if (path && (change.currentPath.startsWith(path) || mapper.path.startsWith(change.currentPath)) && ((deep && change.newValue == change.previousValue) ? !isEqual(change.newValue, change.previousValue) : change.newValue != change.previousValue)) {
-          handler(val, change)
-          mapper.lastValue = val
+          handler(newValue, change)
+          mapper.lastValue = newValue
         } else if (path && (!change.currentPath.startsWith(path) && !path.startsWith(change.currentPath))) {
           // return
           // do nothing

--- a/index.js
+++ b/index.js
@@ -40,12 +40,10 @@ module.exports = ({ initialState = {}, actions = {}, mutations = {} } = {}, { de
 
       if (typeof val != 'undefined') {
         const path = val.__getPath || mapper.path
-        if (mapper.path && (change.currentPath.startsWith(mapper.path) || mapper.path.startsWith(change.currentPath)) && ((deep && change.newValue == change.previousValue) ? !isEqual(change.newValue, change.previousValue) : change.newValue != change.previousValue)) {
+        if (deep && mapper.lastValue == val ? !isEqual(mapper.lastValue, val) : mapper.lastValue != val) {
           handler(val, change)
         } else if (path && (!change.currentPath.startsWith(path) && !path.startsWith(change.currentPath))) return
         else if (get(state, change.currentPath) == val) {
-          handler(val, change)
-        } else if (typeof mapper.lastValue == 'undefined' || (deep && change.newValue == change.previousValue) ? !isEqual(mapper.lastValue, val) : mapper.lastValue != val || (val.__targetPosition && val.__targetPosition != value.__targetPosition)) {
           handler(val, change)
         }
 
@@ -76,10 +74,6 @@ module.exports = ({ initialState = {}, actions = {}, mutations = {} } = {}, { de
       val = mapperFn()
     } catch (e) {
       return observeLater(mapperFn, handler)
-    }
-
-    if (isPrimitive(val)) {
-      throw new Error('You can\'t observe a primitive value')
     }
 
     mapperFn.lastValue = val

--- a/index.js
+++ b/index.js
@@ -42,6 +42,8 @@ module.exports = ({ initialState = {}, actions = {}, mutations = {} } = {}, { de
         const path = val.__getPath || mapper.path
         if (deep && mapper.lastValue == val ? !isEqual(mapper.lastValue, val) : mapper.lastValue != val) {
           handler(val, change)
+        } else if (mapper.path && (change.currentPath.startsWith(mapper.path) || mapper.path.startsWith(change.currentPath)) && ((deep && change.newValue == change.previousValue) ? !isEqual(change.newValue, change.previousValue) : change.newValue != change.previousValue)) {
+          handler(val, change)
         } else if (path && (!change.currentPath.startsWith(path) && !path.startsWith(change.currentPath))) return
         else if (get(state, change.currentPath) == val) {
           handler(val, change)

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const register = require('./lib/register')
 
 module.exports = ({ initialState = {}, actions = {}, mutations = {} } = {}, { deep } = { deep: false }) => {
   const bus = new EventEmitter()
+  bus.setMaxListeners(0)
 
   const state = slim.create(initialState, false, (changes) => {
     changes.forEach(change => {

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ module.exports = ({ initialState = {}, actions = {}, mutations = {} } = {}, { de
         const path = val.__getPath || mapper.path
         if (deep && mapper.lastValue == val ? !isEqual(mapper.lastValue, val) : mapper.lastValue != val) {
           handler(val, change)
-        } else if (mapper.path && (change.currentPath.startsWith(mapper.path) || mapper.path.startsWith(change.currentPath)) && ((deep && change.newValue == change.previousValue) ? !isEqual(change.newValue, change.previousValue) : change.newValue != change.previousValue)) {
+        } else if (path && (change.currentPath.startsWith(path) || mapper.path.startsWith(change.currentPath)) && ((deep && change.newValue == change.previousValue) ? !isEqual(change.newValue, change.previousValue) : change.newValue != change.previousValue)) {
           handler(val, change)
         } else if (path && (!change.currentPath.startsWith(path) && !path.startsWith(change.currentPath))) return
         else if (get(state, change.currentPath) == val) {

--- a/index.js
+++ b/index.js
@@ -45,8 +45,10 @@ module.exports = ({ initialState = {}, actions = {}, mutations = {} } = {}, { de
         } else if (path && (change.currentPath.startsWith(path) || mapper.path.startsWith(change.currentPath)) && ((deep && change.newValue == change.previousValue) ? !isEqual(change.newValue, change.previousValue) : change.newValue != change.previousValue)) {
           handler(val, change)
           mapper.lastValue = val
-        } else if (path && (!change.currentPath.startsWith(path) && !path.startsWith(change.currentPath))) return
-        else if (get(state, change.currentPath) == val) {
+        } else if (path && (!change.currentPath.startsWith(path) && !path.startsWith(change.currentPath))) {
+          // return
+          // do nothing
+        } else if (get(state, change.currentPath) == val) {
           handler(val, change)
           mapper.lastValue = val
         }

--- a/index.js
+++ b/index.js
@@ -40,7 +40,9 @@ module.exports = ({ initialState = {}, actions = {}, mutations = {} } = {}, { de
 
       if (typeof val != 'undefined') {
         const path = val.__getPath || mapper.path
-        if (path && (!change.currentPath.startsWith(path) && !path.startsWith(change.currentPath))) return
+        if (mapper.path && (change.currentPath.startsWith(mapper.path) || mapper.path.startsWith(change.currentPath)) && ((deep && change.newValue == change.previousValue) ? !isEqual(change.newValue, change.previousValue) : change.newValue != change.previousValue)) {
+          handler(val, change)
+        } else if (path && (!change.currentPath.startsWith(path) && !path.startsWith(change.currentPath))) return
         else if (get(state, change.currentPath) == val) {
           handler(val, change)
         } else if (typeof mapper.lastValue == 'undefined' || (deep && change.newValue == change.previousValue) ? !isEqual(mapper.lastValue, val) : mapper.lastValue != val || (val.__targetPosition && val.__targetPosition != value.__targetPosition)) {

--- a/index.js
+++ b/index.js
@@ -38,7 +38,8 @@ module.exports = ({ initialState = {}, actions = {}, mutations = {} } = {}, { de
       }
 
       if (typeof val != 'undefined') {
-        if (typeof val.__getPath != 'undefined' && !change.currentPath.startsWith(val.__getPath)) return
+        const path = val.__getPath || mapper.path
+        if (path && !change.currentPath.startsWith(path)) return
         else if (get(state, change.currentPath) == val) {
           handler(val, change)
         } else if (typeof mapper.lastValue == 'undefined' || deep ? !isEqual(mapper.lastValue, val) : mapper.lastValue != val || (val.__targetPosition && val.__targetPosition != value.__targetPosition)) {
@@ -63,6 +64,7 @@ module.exports = ({ initialState = {}, actions = {}, mutations = {} } = {}, { de
 
     if (typeof mapper == 'string') {
       mapperFn = () => get(state, mapper)
+      mapperFn.path = mapper
     }
 
     let val

--- a/lib/register.js
+++ b/lib/register.js
@@ -1,5 +1,3 @@
-const get = require('lodash.get')
-
 module.exports = observe => ({ Component }) => {
   Component.prototype.__regie_changes__ = Component.prototype.__regie_changes__ || []
 

--- a/lib/register.js
+++ b/lib/register.js
@@ -1,5 +1,3 @@
-const get = require('lodash.get')
-
 module.exports = (observe, state) => ({ Component }) => {
   Component.prototype.__regie_changes__ = Component.prototype.__regie_changes__ || []
 

--- a/lib/register.js
+++ b/lib/register.js
@@ -14,31 +14,31 @@ module.exports = (observe, state) => ({ Component }) => {
       const methods = Object.getOwnPropertyNames(Object.getPrototypeOf(this))
       const observeMethods = methods.filter(x => x.startsWith('observe'))
       const mapStateMethods = (this.mapStateToProps && this.mapStateToProps()) || {}
-      if (mapStateMethods) {
-        Object.keys(mapStateMethods)
-          .forEach(method => {
-            let propValue
+      Object.keys(mapStateMethods)
+        .forEach(method => {
+          let propValue
 
+          if (typeof mapStateMethods[method] == 'string') {
+            propValue = get(state, mapStateMethods[method])
+          } else if (typeof mapStateMethods[method] == 'function') {
             try {
-              if (typeof mapStateMethods[method] == 'string') {
-                propValue = get(state, mapStateMethods[method])
-              } else if (typeof mapStateMethods[method] == 'function') {
-                propValue = mapStateMethods[method](state)
-              }
+              propValue = mapStateMethods[method](state)
             } catch (e) {}
+          } else {
+            throw new Error(`Invalid type '${typeof mapStateMethods[method]}' for '${method}'. mapStateToProps should return an object whose properties are either strings or functions.`)
+          }
 
-            Object.defineProperty(this.props, method, {
-              get: () => propValue,
-              set: newValue => {
-                throw new Error(`Refusing to update '${method}' to ${newValue}. Please use a mutation to mutate the state.`)
-              }
-            })
-
-            changes.push([comp => mapStateMethods[method], comp => (newValue, change) => {
-              propValue = newValue
-            }])
+          Object.defineProperty(this.props, method, {
+            get: () => propValue,
+            set: newValue => {
+              throw new Error(`Refusing to update '${method}' to ${newValue}. Please use a mutation to mutate the state.`)
+            }
           })
-      }
+
+          changes.push([comp => mapStateMethods[method], comp => (newValue, change) => {
+            propValue = newValue
+          }])
+        })
 
       observeMethods
         .forEach(method => {
@@ -48,15 +48,12 @@ module.exports = (observe, state) => ({ Component }) => {
             if (path in mapStateMethods) {
               if (typeof mapStateMethods[path] == 'string') {
                 return mapStateMethods[path]
-              } else if (typeof mapStateMethods[path] == 'function') {
+              } else { // if (typeof mapStateMethods[path] == 'function') { // removed due to line coverage error
                 return state => mapStateMethods[path](state)
               }
-            }
-
-            if (!(firstPath in comp.props)) {
+            } else if (!(firstPath in comp.props)) {
               throw new Error(`Trying to observe '${firstPath}' prop in the '${comp.constructor.name}' component but it hasn't been passed down as a prop during instantiation.`)
-            }
-            if (!(comp.props[firstPath] && comp.props[firstPath].__getPath)) {
+            } else if (!(comp.props[firstPath] && comp.props[firstPath].__getPath)) {
               throw new Error(`You are passing down '${firstPath}' as a prop to the '${comp.constructor.name}' component but it is a primitive value in the store and can't be passed down as a prop. Consider passing its parent object as a prop instead and you can still observe the primitive in the '${comp.constructor.name}' component.`)
             }
             return comp.props[firstPath].__getPath.split('.').concat(restPath).join('.')

--- a/lib/register.js
+++ b/lib/register.js
@@ -1,3 +1,5 @@
+const get = require('lodash.get')
+
 module.exports = (observe, state) => ({ Component }) => {
   Component.prototype.__regie_changes__ = Component.prototype.__regie_changes__ || []
 
@@ -18,7 +20,11 @@ module.exports = (observe, state) => ({ Component }) => {
             let propValue
 
             try {
-              propValue = mapStateMethods[method](state)
+              if (typeof mapStateMethods[method] == 'string') {
+                propValue = get(state, mapStateMethods[method])
+              } else if (typeof mapStateMethods[method] == 'function') {
+                propValue = mapStateMethods[method](state)
+              }
             } catch (e) {}
 
             Object.defineProperty(this.props, method, {
@@ -40,7 +46,11 @@ module.exports = (observe, state) => ({ Component }) => {
           changes.push([comp => {
             const [firstPath, ...restPath] = path.split('.')
             if (path in mapStateMethods) {
-              return state => mapStateMethods[path](state)
+              if (typeof mapStateMethods[path] == 'string') {
+                return mapStateMethods[path]
+              } else if (typeof mapStateMethods[path] == 'function') {
+                return state => mapStateMethods[path](state)
+              }
             }
 
             if (!(firstPath in comp.props)) {

--- a/lib/register.js
+++ b/lib/register.js
@@ -11,6 +11,17 @@ module.exports = (observe, state) => ({ Component }) => {
     if (!changes.length) {
       changes = []
 
+      for (let propName in this.props) {
+        if (this.props[propName] == null) continue
+
+        // Update props when the values passed down are overridden at the root
+        changes.unshift([ _ => {
+          return this.props[propName].__getPath
+        }, cmp => newValue => {
+          this.props[propName] = newValue
+        }])
+      }
+
       const methods = Object.getOwnPropertyNames(Object.getPrototypeOf(this))
       const observeMethods = methods.filter(x => x.startsWith('observe'))
       const mapStateMethods = (this.mapStateToProps && this.mapStateToProps()) || {}

--- a/lib/register.js
+++ b/lib/register.js
@@ -15,7 +15,16 @@ module.exports = observe => ({ Component }) => {
         .filter(x => x.startsWith('observe'))
         .forEach(method => {
           const path = method.slice(8)
-          changes.push([ comp => () => get(comp.props, path), comp => comp[method].bind(comp) ])
+          changes.push([comp => {
+            const [firstPath, ...restPath] = path.split('.')
+            if (!(firstPath in comp.props)) {
+              throw new Error(`Trying to observe '${firstPath}' prop in the '${comp.constructor.name}' component but it hasn't been passed down as a prop during instantiation.`)
+            }
+            if (!comp.props[firstPath].__getPath) {
+              throw new Error(`You are passing down '${firstPath}' as a prop to the '${comp.constructor.name}' component but it is a primitive value in the store and can't be passed down as a prop. Consider passing its parent object as a prop instead and you can still observe the primitive in the '${comp.constructor.name}' component.`)
+            }
+            return comp.props[firstPath].__getPath.split('.').concat(restPath).join('.')
+          }, comp => comp[method].bind(comp)])
         })
 
       this.constructor.prototype.__regie_changes__ = changes

--- a/lib/register.js
+++ b/lib/register.js
@@ -12,7 +12,7 @@ module.exports = (observe, state) => ({ Component }) => {
       changes = []
 
       for (let propName in this.props) {
-        if (this.props[propName] == null) continue
+        if (this.props[propName] == null || typeof this.props[propName] == 'undefined') continue
 
         // Update props when the values passed down are overridden at the root
 

--- a/lib/register.js
+++ b/lib/register.js
@@ -9,8 +9,11 @@ module.exports = observe => ({ Component }) => {
     if (!changes.length) {
       changes = []
 
-      Object.getOwnPropertyNames(Object.getPrototypeOf(this))
-        .filter(x => x.startsWith('observe'))
+      const methods = Object.getOwnPropertyNames(Object.getPrototypeOf(this))
+      const observeMethods = methods.filter(x => x.startsWith('observe'))
+      const mapStateMethods = methods.filter(x => x.startsWith('mapState'))
+
+      observeMethods
         .forEach(method => {
           const path = method.slice(8)
           changes.push([comp => {
@@ -23,6 +26,15 @@ module.exports = observe => ({ Component }) => {
             }
             return comp.props[firstPath].__getPath.split('.').concat(restPath).join('.')
           }, comp => comp[method].bind(comp)])
+        })
+
+      mapStateMethods
+        .forEach(method => {
+          const path = method.slice(9)
+          if (!path.trim()) {
+            throw new Error(`Can't map empty state in '${this.constructor.name}' component`)
+          }
+          changes.push([comp => path, comp => comp[method].bind(comp)])
         })
 
       this.constructor.prototype.__regie_changes__ = changes

--- a/lib/register.js
+++ b/lib/register.js
@@ -18,7 +18,7 @@ module.exports = observe => ({ Component }) => {
             if (!(firstPath in comp.props)) {
               throw new Error(`Trying to observe '${firstPath}' prop in the '${comp.constructor.name}' component but it hasn't been passed down as a prop during instantiation.`)
             }
-            if (!comp.props[firstPath].__getPath) {
+            if (!(comp.props[firstPath] && comp.props[firstPath].__getPath)) {
               throw new Error(`You are passing down '${firstPath}' as a prop to the '${comp.constructor.name}' component but it is a primitive value in the store and can't be passed down as a prop. Consider passing its parent object as a prop instead and you can still observe the primitive in the '${comp.constructor.name}' component.`)
             }
             return comp.props[firstPath].__getPath.split('.').concat(restPath).join('.')

--- a/lib/register.js
+++ b/lib/register.js
@@ -1,4 +1,6 @@
-module.exports = observe => ({ Component }) => {
+const get = require('lodash.get')
+
+module.exports = (observe, state) => ({ Component }) => {
   Component.prototype.__regie_changes__ = Component.prototype.__regie_changes__ || []
 
   const originalHook = Component.prototype.createdHooks
@@ -11,13 +13,38 @@ module.exports = observe => ({ Component }) => {
 
       const methods = Object.getOwnPropertyNames(Object.getPrototypeOf(this))
       const observeMethods = methods.filter(x => x.startsWith('observe'))
-      const mapStateMethods = methods.filter(x => x.startsWith('mapState'))
+      const mapStateMethods = (this.mapStateToProps && this.mapStateToProps()) || {}
+      if (mapStateMethods) {
+        Object.keys(mapStateMethods)
+          .forEach(method => {
+            let propValue
+
+            try {
+              propValue = mapStateMethods[method](state)
+            } catch (e) {}
+
+            Object.defineProperty(this.props, method, {
+              get: () => propValue,
+              set: newValue => {
+                throw new Error(`Refusing to update '${method}' to ${newValue}. Please use a mutation to mutate the state.`)
+              }
+            })
+
+            changes.push([comp => mapStateMethods[method], comp => (newValue, change) => {
+              propValue = newValue
+            }])
+          })
+      }
 
       observeMethods
         .forEach(method => {
           const path = method.slice(8)
           changes.push([comp => {
             const [firstPath, ...restPath] = path.split('.')
+            if (path in mapStateMethods) {
+              return state => mapStateMethods[path](state)
+            }
+
             if (!(firstPath in comp.props)) {
               throw new Error(`Trying to observe '${firstPath}' prop in the '${comp.constructor.name}' component but it hasn't been passed down as a prop during instantiation.`)
             }
@@ -26,15 +53,6 @@ module.exports = observe => ({ Component }) => {
             }
             return comp.props[firstPath].__getPath.split('.').concat(restPath).join('.')
           }, comp => comp[method].bind(comp)])
-        })
-
-      mapStateMethods
-        .forEach(method => {
-          const path = method.slice(9)
-          if (!path.trim()) {
-            throw new Error(`Can't map empty state in '${this.constructor.name}' component`)
-          }
-          changes.push([comp => path, comp => comp[method].bind(comp)])
         })
 
       this.constructor.prototype.__regie_changes__ = changes

--- a/lib/register.js
+++ b/lib/register.js
@@ -15,9 +15,9 @@ module.exports = (observe, state) => ({ Component }) => {
         if (this.props[propName] == null) continue
 
         // Update props when the values passed down are overridden at the root
-        changes.unshift([ _ => {
-          return this.props[propName].__getPath
-        }, cmp => newValue => {
+
+        const path = this.props[propName].__getPath
+        changes.unshift([ _ => path, cmp => newValue => {
           this.props[propName] = newValue
         }])
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.6",
+  "version": "2.0.0-beta.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.17",
+  "version": "2.0.0-beta.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.14",
+  "version": "2.0.0-beta.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.20",
+  "version": "2.0.0-beta.21",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.18",
+  "version": "2.0.0-beta.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.9",
+  "version": "2.0.0-beta.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.16",
+  "version": "2.0.0-beta.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.21",
+  "version": "2.0.0-beta.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.22",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "1.3.1",
+  "version": "2.0.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.10",
+  "version": "2.0.0-beta.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4500,6 +4500,11 @@
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
     "lodash.islength": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.islength/-/lodash.islength-4.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.7",
+  "version": "2.0.0-beta.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.11",
+  "version": "2.0.0-beta.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -139,6 +139,28 @@
         "@babel/types": "^7.0.0"
       }
     },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.4.tgz",
+      "integrity": "sha512-m5j85pK/KZhuSdM/8cHUABQTAslV47OjfIB9Cc7P+PvlAoBzdb79BGNfw8RhT5Mq3p+xGd0ZfAKixbrUZx0C7A==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.10.4"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
+          "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
     "@babel/helper-module-imports": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
@@ -160,6 +182,28 @@
         "@babel/template": "^7.2.2",
         "@babel/types": "^7.2.2",
         "lodash": "^4.17.10"
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+      "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.10.4"
+      },
+      "dependencies": {
+        "@babel/types": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
+          "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-plugin-utils": {
@@ -190,6 +234,126 @@
         "@babel/types": "^7.0.0"
       }
     },
+    "@babel/helper-replace-supers": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
+      "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-member-expression-to-functions": "^7.10.4",
+        "@babel/helper-optimise-call-expression": "^7.10.4",
+        "@babel/traverse": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+          "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.10.4"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.4.tgz",
+          "integrity": "sha512-toLIHUIAgcQygFZRAQcsLQV3CBuX6yOIru1kJk/qqqvcRmZrYe6WavZTSG+bB8MxhnL9YPf+pKQfuiP161q7ng==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.10.4",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.13",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+          "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.10.4",
+            "@babel/template": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+          "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
+          "integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+          "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.4.tgz",
+          "integrity": "sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+          "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.10.4",
+            "@babel/parser": "^7.10.4",
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.4.tgz",
+          "integrity": "sha512-aSy7p5THgSYm4YyxNGz6jZpXf+Ok40QF3aA2LyIONkDHpAcJzDUqlCKXv6peqYUs2gmic849C/t2HKw2a2K20Q==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.10.4",
+            "@babel/generator": "^7.10.4",
+            "@babel/helper-function-name": "^7.10.4",
+            "@babel/helper-split-export-declaration": "^7.10.4",
+            "@babel/parser": "^7.10.4",
+            "@babel/types": "^7.10.4",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/types": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
+          "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "lodash": "^4.17.13",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
     "@babel/helper-simple-access": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.1.0.tgz",
@@ -208,6 +372,12 @@
       "requires": {
         "@babel/types": "^7.0.0"
       }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+      "dev": true
     },
     "@babel/helper-wrap-function": {
       "version": "7.2.0",
@@ -350,6 +520,16 @@
         "@babel/helper-simple-access": "^7.1.0"
       }
     },
+    "@babel/runtime-corejs3": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.10.4.tgz",
+      "integrity": "sha512-BFlgP2SoLO9HJX9WBwN67gHWMBhDX/eDz64Jajd6mR/UAUzqrNMm99d4qHnVaKscAElZoFiPv+JpR/Siud5lXw==",
+      "dev": true,
+      "requires": {
+        "core-js-pure": "^3.0.0",
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@babel/template": {
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
@@ -399,13 +579,14 @@
       }
     },
     "@istanbuljs/load-nyc-config": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
-      "integrity": "sha512-ZR0rq/f/E4f4XcgnDvtMWXCUJpi8eO0rssVhmztsZqLIEFA9UUP9zmpE0VxlM+kv/E1ul2I876Fwil2ayptDVg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
       "dev": true,
       "requires": {
         "camelcase": "^5.3.1",
         "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
         "js-yaml": "^3.13.1",
         "resolve-from": "^5.0.0"
       },
@@ -436,9 +617,9 @@
           }
         },
         "p-limit": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -989,9 +1170,9 @@
       },
       "dependencies": {
         "make-dir": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
-          "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+          "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
           "dev": true,
           "requires": {
             "semver": "^6.0.0"
@@ -1409,6 +1590,12 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.3.tgz",
       "integrity": "sha512-l00tmFFZOBHtYhN4Cz7k32VM7vTn3rE2ANjQDxdEN6zmXZ/xq1jQuutnmHvMG1ZJ7xd72+TA5YpUK8wz3rWsfQ==",
+      "dev": true
+    },
+    "core-js-pure": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
+      "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==",
       "dev": true
     },
     "core-util-is": {
@@ -2467,9 +2654,9 @@
       }
     },
     "find-cache-dir": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.0.tgz",
-      "integrity": "sha512-PtXtQb7IrD8O+h6Cq1dbpJH5NzD8+9keN1zZ0YlpDzl1PwXEJEBj6u1Xa92t1Hwluoozd9TNKul5Hi2iqpsWwg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+      "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
       "dev": true,
       "requires": {
         "commondir": "^1.0.1",
@@ -2497,18 +2684,18 @@
           }
         },
         "make-dir": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
-          "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+          "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
           "dev": true,
           "requires": {
             "semver": "^6.0.0"
           }
         },
         "p-limit": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -2584,9 +2771,9 @@
       },
       "dependencies": {
         "cross-spawn": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
-          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
           "dev": true,
           "requires": {
             "path-key": "^3.1.0",
@@ -3302,6 +3489,12 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
+    "get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true
+    },
     "get-port": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-4.1.0.tgz",
@@ -3520,9 +3713,9 @@
       "dev": true
     },
     "html-escaper": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.0.tgz",
-      "integrity": "sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
     "http-signature": {
@@ -3966,46 +4159,44 @@
       }
     },
     "istanbul-lib-instrument": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.1.tgz",
-      "integrity": "sha512-imIchxnodll7pvQBYOqUu88EufLCU56LMeFPZZM/fJZ1irYcYdqroaV+ACK1Ila8ls09iEYArp+nqyC6lW1Vfg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+      "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.7.5",
-        "@babel/parser": "^7.7.5",
-        "@babel/template": "^7.7.4",
-        "@babel/traverse": "^7.7.4",
         "@istanbuljs/schema": "^0.1.2",
         "istanbul-lib-coverage": "^3.0.0",
         "semver": "^6.3.0"
       },
       "dependencies": {
         "@babel/code-frame": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-          "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+          "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
           "dev": true,
           "requires": {
-            "@babel/highlight": "^7.8.3"
+            "@babel/highlight": "^7.10.4"
           }
         },
         "@babel/core": {
-          "version": "7.8.6",
-          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.6.tgz",
-          "integrity": "sha512-Sheg7yEJD51YHAvLEV/7Uvw95AeWqYPL3Vk3zGujJKIhJ+8oLw2ALaf3hbucILhKsgSoADOvtKRJuNVdcJkOrg==",
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.10.4.tgz",
+          "integrity": "sha512-3A0tS0HWpy4XujGc7QtOIHTeNwUgWaZc/WuS5YQrfhU67jnVmsD6OGPc1AKHH0LJHQICGncy3+YUjIhVlfDdcA==",
           "dev": true,
           "requires": {
-            "@babel/code-frame": "^7.8.3",
-            "@babel/generator": "^7.8.6",
-            "@babel/helpers": "^7.8.4",
-            "@babel/parser": "^7.8.6",
-            "@babel/template": "^7.8.6",
-            "@babel/traverse": "^7.8.6",
-            "@babel/types": "^7.8.6",
+            "@babel/code-frame": "^7.10.4",
+            "@babel/generator": "^7.10.4",
+            "@babel/helper-module-transforms": "^7.10.4",
+            "@babel/helpers": "^7.10.4",
+            "@babel/parser": "^7.10.4",
+            "@babel/template": "^7.10.4",
+            "@babel/traverse": "^7.10.4",
+            "@babel/types": "^7.10.4",
             "convert-source-map": "^1.7.0",
             "debug": "^4.1.0",
             "gensync": "^1.0.0-beta.1",
-            "json5": "^2.1.0",
+            "json5": "^2.1.2",
             "lodash": "^4.17.13",
             "resolve": "^1.3.2",
             "semver": "^5.4.1",
@@ -4021,109 +4212,143 @@
           }
         },
         "@babel/generator": {
-          "version": "7.8.6",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.6.tgz",
-          "integrity": "sha512-4bpOR5ZBz+wWcMeVtcf7FbjcFzCp+817z2/gHNncIRcM9MmKzUhtWCYAq27RAfUrAFwb+OCG1s9WEaVxfi6cjg==",
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.4.tgz",
+          "integrity": "sha512-toLIHUIAgcQygFZRAQcsLQV3CBuX6yOIru1kJk/qqqvcRmZrYe6WavZTSG+bB8MxhnL9YPf+pKQfuiP161q7ng==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.8.6",
+            "@babel/types": "^7.10.4",
             "jsesc": "^2.5.1",
             "lodash": "^4.17.13",
             "source-map": "^0.5.0"
           }
         },
         "@babel/helper-function-name": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
-          "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+          "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
           "dev": true,
           "requires": {
-            "@babel/helper-get-function-arity": "^7.8.3",
-            "@babel/template": "^7.8.3",
-            "@babel/types": "^7.8.3"
+            "@babel/helper-get-function-arity": "^7.10.4",
+            "@babel/template": "^7.10.4",
+            "@babel/types": "^7.10.4"
           }
         },
         "@babel/helper-get-function-arity": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
-          "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+          "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.8.3"
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-module-imports": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
+          "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.10.4"
+          }
+        },
+        "@babel/helper-module-transforms": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.4.tgz",
+          "integrity": "sha512-Er2FQX0oa3nV7eM1o0tNCTx7izmQtwAQsIiaLRWtavAAEcskb0XJ5OjJbVrYXWOTr8om921Scabn4/tzlx7j1Q==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.10.4",
+            "@babel/helper-replace-supers": "^7.10.4",
+            "@babel/helper-simple-access": "^7.10.4",
+            "@babel/helper-split-export-declaration": "^7.10.4",
+            "@babel/template": "^7.10.4",
+            "@babel/types": "^7.10.4",
+            "lodash": "^4.17.13"
+          }
+        },
+        "@babel/helper-simple-access": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
+          "integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
+          "dev": true,
+          "requires": {
+            "@babel/template": "^7.10.4",
+            "@babel/types": "^7.10.4"
           }
         },
         "@babel/helper-split-export-declaration": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
-          "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
+          "integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
           "dev": true,
           "requires": {
-            "@babel/types": "^7.8.3"
+            "@babel/types": "^7.10.4"
           }
         },
         "@babel/helpers": {
-          "version": "7.8.4",
-          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.8.4.tgz",
-          "integrity": "sha512-VPbe7wcQ4chu4TDQjimHv/5tj73qz88o12EPkO2ValS2QiQS/1F2SsjyIGNnAD0vF/nZS6Cf9i+vW6HIlnaR8w==",
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
+          "integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
           "dev": true,
           "requires": {
-            "@babel/template": "^7.8.3",
-            "@babel/traverse": "^7.8.4",
-            "@babel/types": "^7.8.3"
+            "@babel/template": "^7.10.4",
+            "@babel/traverse": "^7.10.4",
+            "@babel/types": "^7.10.4"
           }
         },
         "@babel/highlight": {
-          "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-          "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+          "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
           "dev": true,
           "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
             "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
             "js-tokens": "^4.0.0"
           }
         },
         "@babel/parser": {
-          "version": "7.8.6",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.6.tgz",
-          "integrity": "sha512-trGNYSfwq5s0SgM1BMEB8hX3NDmO7EP2wsDGDexiaKMB92BaRpS+qZfpkMqUBhcsOTBwNy9B/jieo4ad/t/z2g==",
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.4.tgz",
+          "integrity": "sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA==",
           "dev": true
         },
         "@babel/template": {
-          "version": "7.8.6",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
-          "integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+          "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
           "dev": true,
           "requires": {
-            "@babel/code-frame": "^7.8.3",
-            "@babel/parser": "^7.8.6",
-            "@babel/types": "^7.8.6"
+            "@babel/code-frame": "^7.10.4",
+            "@babel/parser": "^7.10.4",
+            "@babel/types": "^7.10.4"
           }
         },
         "@babel/traverse": {
-          "version": "7.8.6",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
-          "integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.4.tgz",
+          "integrity": "sha512-aSy7p5THgSYm4YyxNGz6jZpXf+Ok40QF3aA2LyIONkDHpAcJzDUqlCKXv6peqYUs2gmic849C/t2HKw2a2K20Q==",
           "dev": true,
           "requires": {
-            "@babel/code-frame": "^7.8.3",
-            "@babel/generator": "^7.8.6",
-            "@babel/helper-function-name": "^7.8.3",
-            "@babel/helper-split-export-declaration": "^7.8.3",
-            "@babel/parser": "^7.8.6",
-            "@babel/types": "^7.8.6",
+            "@babel/code-frame": "^7.10.4",
+            "@babel/generator": "^7.10.4",
+            "@babel/helper-function-name": "^7.10.4",
+            "@babel/helper-split-export-declaration": "^7.10.4",
+            "@babel/parser": "^7.10.4",
+            "@babel/types": "^7.10.4",
             "debug": "^4.1.0",
             "globals": "^11.1.0",
             "lodash": "^4.17.13"
           }
         },
         "@babel/types": {
-          "version": "7.8.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.6.tgz",
-          "integrity": "sha512-wqz7pgWMIrht3gquyEFPVXeXCti72Rm8ep9b5tQKz9Yg9LzJA3HxosF1SB3Kc81KD1A3XBkkVYtJvCKS2Z/QrA==",
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
+          "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
           "dev": true,
           "requires": {
-            "esutils": "^2.0.2",
+            "@babel/helper-validator-identifier": "^7.10.4",
             "lodash": "^4.17.13",
             "to-fast-properties": "^2.0.0"
           }
@@ -4136,6 +4361,21 @@
           "requires": {
             "safe-buffer": "~5.1.1"
           }
+        },
+        "json5": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
         },
         "semver": {
           "version": "6.3.0",
@@ -4161,9 +4401,9 @@
       },
       "dependencies": {
         "cross-spawn": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
-          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
           "dev": true,
           "requires": {
             "path-key": "^3.1.0",
@@ -4172,9 +4412,9 @@
           }
         },
         "make-dir": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
-          "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+          "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
           "dev": true,
           "requires": {
             "semver": "^6.0.0"
@@ -4260,9 +4500,9 @@
           "dev": true
         },
         "make-dir": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
-          "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+          "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
           "dev": true,
           "requires": {
             "semver": "^6.0.0"
@@ -4305,9 +4545,9 @@
       }
     },
     "istanbul-reports": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-      "integrity": "sha512-2osTcC8zcOSUkImzN2EWQta3Vdi4WjjKw99P2yWx5mLnigAM0Rd5uYFn1cf2i/Ois45GkNjaoTqc5CxgMSX80A==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+      "integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
       "dev": true,
       "requires": {
         "html-escaper": "^2.0.0",
@@ -4841,9 +5081,9 @@
       }
     },
     "nyc": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-15.0.0.tgz",
-      "integrity": "sha512-qcLBlNCKMDVuKb7d1fpxjPR8sHeMVX0CHarXAVzrVWoFrigCkYR8xcrjfXSPi5HXM7EU78L6ywO7w1c5rZNCNg==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-15.1.0.tgz",
+      "integrity": "sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==",
       "dev": true,
       "requires": {
         "@istanbuljs/load-nyc-config": "^1.0.0",
@@ -4854,6 +5094,7 @@
         "find-cache-dir": "^3.2.0",
         "find-up": "^4.1.0",
         "foreground-child": "^2.0.0",
+        "get-package-type": "^0.1.0",
         "glob": "^7.1.6",
         "istanbul-lib-coverage": "^3.0.0",
         "istanbul-lib-hook": "^3.0.0",
@@ -4861,10 +5102,9 @@
         "istanbul-lib-processinfo": "^2.0.2",
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
-        "istanbul-reports": "^3.0.0",
-        "js-yaml": "^3.13.1",
+        "istanbul-reports": "^3.0.2",
         "make-dir": "^3.0.0",
-        "node-preload": "^0.2.0",
+        "node-preload": "^0.2.1",
         "p-map": "^3.0.0",
         "process-on-spawn": "^1.0.0",
         "resolve-from": "^5.0.0",
@@ -4872,7 +5112,6 @@
         "signal-exit": "^3.0.2",
         "spawn-wrap": "^2.0.0",
         "test-exclude": "^6.0.0",
-        "uuid": "^3.3.3",
         "yargs": "^15.0.2"
       },
       "dependencies": {
@@ -4919,18 +5158,18 @@
           }
         },
         "make-dir": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
-          "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+          "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
           "dev": true,
           "requires": {
             "semver": "^6.0.0"
           }
         },
         "p-limit": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -4979,12 +5218,6 @@
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
           "dev": true
         }
       }
@@ -5596,6 +5829,12 @@
         "regenerate": "^1.4.0"
       }
     },
+    "regenerator-runtime": {
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+      "dev": true
+    },
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -6107,9 +6346,9 @@
       },
       "dependencies": {
         "make-dir": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
-          "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+          "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
           "dev": true,
           "requires": {
             "semver": "^6.0.0"
@@ -6937,6 +7176,15 @@
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
       "dev": true
     },
+    "xregexp": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.3.0.tgz",
+      "integrity": "sha512-7jXDIFXh5yJ/orPn4SXjuVrWWoi4Cr8jfV1eHv9CixKSbU+jY4mxfrBwAuDvupPNKpMUY+FeIqsVw/JLT9+B8g==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime-corejs3": "^7.8.3"
+      }
+    },
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
@@ -6956,13 +7204,13 @@
       "dev": true
     },
     "yargs": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.1.0.tgz",
-      "integrity": "sha512-T39FNN1b6hCW4SOIk1XyTOWxtXdcen0t+XYrysQmChzSipvhBO8Bj0nK1ozAasdk24dNWuMZvr4k24nz+8HHLg==",
+      "version": "15.4.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.0.tgz",
+      "integrity": "sha512-D3fRFnZwLWp8jVAAhPZBsmeIHY8tTsb8ItV9KaAaopmC6wde2u6Yw29JBIZHXw14kgkRnYmDgmQU4FVMDlIsWw==",
       "dev": true,
       "requires": {
         "cliui": "^6.0.0",
-        "decamelize": "^1.2.0",
+        "decamelize": "^3.2.0",
         "find-up": "^4.1.0",
         "get-caller-file": "^2.0.1",
         "require-directory": "^2.1.1",
@@ -6971,7 +7219,7 @@
         "string-width": "^4.2.0",
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
-        "yargs-parser": "^16.1.0"
+        "yargs-parser": "^18.1.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -6985,6 +7233,15 @@
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
           "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
           "dev": true
+        },
+        "decamelize": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-3.2.0.tgz",
+          "integrity": "sha512-4TgkVUsmmu7oCSyGBm5FvfMoACuoh9EOidm7V5/J2X2djAwwt57qb3F2KMP2ITqODTCSwb+YRV+0Zqrv18k/hw==",
+          "dev": true,
+          "requires": {
+            "xregexp": "^4.2.4"
+          }
         },
         "find-up": {
           "version": "4.1.0",
@@ -7012,9 +7269,9 @@
           }
         },
         "p-limit": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -7056,13 +7313,21 @@
           }
         },
         "yargs-parser": {
-          "version": "16.1.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
-          "integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"
+          },
+          "dependencies": {
+            "decamelize": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+              "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+              "dev": true
+            }
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.12",
+  "version": "2.0.0-beta.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3873,6 +3873,11 @@
         "isobject": "^3.0.1"
       }
     },
+    "is-primitive": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-3.0.1.tgz",
+      "integrity": "sha512-GljRxhWvlCNRfZyORiH77FwdFwGcMO620o37EOYC0ORWdq+WYNVqW0w2Juzew4M+L81l6/QS3t5gkkihyRqv9w=="
+    },
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.19",
+  "version": "2.0.0-beta.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.15",
+  "version": "2.0.0-beta.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.13",
+  "version": "2.0.0-beta.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.5",
   "description": "An observable state management tool for vanilla JS applications based on Proxies",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.14",
+  "version": "2.0.0-beta.15",
   "description": "An observable state management tool for vanilla JS applications based on Proxies",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.11",
+  "version": "2.0.0-beta.12",
   "description": "An observable state management tool for vanilla JS applications based on Proxies",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.9",
+  "version": "2.0.0-beta.10",
   "description": "An observable state management tool for vanilla JS applications based on Proxies",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.15",
+  "version": "2.0.0-beta.16",
   "description": "An observable state management tool for vanilla JS applications based on Proxies",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.10",
+  "version": "2.0.0-beta.11",
   "description": "An observable state management tool for vanilla JS applications based on Proxies",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.7",
+  "version": "2.0.0-beta.8",
   "description": "An observable state management tool for vanilla JS applications based on Proxies",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "description": "An observable state management tool for vanilla JS applications based on Proxies",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.20",
+  "version": "2.0.0-beta.21",
   "description": "An observable state management tool for vanilla JS applications based on Proxies",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.6",
+  "version": "2.0.0-beta.7",
   "description": "An observable state management tool for vanilla JS applications based on Proxies",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.17",
+  "version": "2.0.0-beta.18",
   "description": "An observable state management tool for vanilla JS applications based on Proxies",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.3",
   "description": "An observable state management tool for vanilla JS applications based on Proxies",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.19",
+  "version": "2.0.0-beta.20",
   "description": "An observable state management tool for vanilla JS applications based on Proxies",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.18",
+  "version": "2.0.0-beta.19",
   "description": "An observable state management tool for vanilla JS applications based on Proxies",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.21",
+  "version": "2.0.0-beta.22",
   "description": "An observable state management tool for vanilla JS applications based on Proxies",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.8",
+  "version": "2.0.0-beta.9",
   "description": "An observable state management tool for vanilla JS applications based on Proxies",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.16",
+  "version": "2.0.0-beta.17",
   "description": "An observable state management tool for vanilla JS applications based on Proxies",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "lodash.get": "^4.4.2",
+    "lodash.isequal": "^4.5.0",
     "observable-slim": "0.1.5"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "Armagan Amcalar <armagan@amcalar.com>",
   "license": "MIT",
   "dependencies": {
+    "is-primitive": "^3.0.1",
     "lodash.get": "^4.4.2",
     "lodash.isequal": "^4.5.0",
     "observable-slim": "0.1.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.22",
+  "version": "2.0.0",
   "description": "An observable state management tool for vanilla JS applications based on Proxies",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.5",
+  "version": "2.0.0-beta.6",
   "description": "An observable state management tool for vanilla JS applications based on Proxies",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.13",
+  "version": "2.0.0-beta.14",
   "description": "An observable state management tool for vanilla JS applications based on Proxies",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "2.0.0-beta.12",
+  "version": "2.0.0-beta.13",
   "description": "An observable state management tool for vanilla JS applications based on Proxies",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regie",
-  "version": "1.3.1",
+  "version": "2.0.0-beta.0",
   "description": "An observable state management tool for vanilla JS applications based on Proxies",
   "main": "index.js",
   "keywords": [

--- a/test/actions-mutations.js
+++ b/test/actions-mutations.js
@@ -56,3 +56,36 @@ test.cb('Observe state updated by a mutation through an action', t => {
 
   actions.setValue(val)
 })
+
+test('Observe state deep change of an object', t => {
+  const newVal = { prop1: 3, prop2: 2 }
+  const { actions, observe, state } = regie({
+    initialState: {
+      val: { prop1: 1, prop2: 2 }
+    },
+    actions: {
+      setValue ({ mutations }, val) {
+        mutations.setValue(val)
+      }
+    },
+    mutations: {
+      setValue ({ state }, val) {
+        state.val = val
+      }
+    }
+  }, { deep: true })
+
+  observe(() => state.val.prop1, newValue => {
+    t.is(newValue, newVal.prop1)
+  })
+
+  observe(() => state.val.prop2, (newValue, change) => {
+    t.fail()
+  })
+
+  observe(() => state.val, newValue => {
+    t.deepEqual(newValue, newVal)
+  })
+
+  actions.setValue(newVal)
+})

--- a/test/future-state.js
+++ b/test/future-state.js
@@ -98,7 +98,7 @@ test.cb('Observe future array of parent with mapper function and use its proxy o
   state.val.val = [val2]
 })
 
-test.cb.skip('Observe future array of parent with mapper function and use its proxy once it\'s available even if something else changes', t => {
+test.cb('Observe future array of parent with mapper function and use its proxy once it\'s available even if something else changes', t => {
   const { state, observe } = t.context.store
 
   const val1 = Math.random()

--- a/test/future-state.js
+++ b/test/future-state.js
@@ -98,7 +98,7 @@ test.cb('Observe future array of parent with mapper function and use its proxy o
   state.val.val = [val2]
 })
 
-test.cb('Observe future array of parent with mapper function and use its proxy once it\'s available even if something else changes', t => {
+test.cb.skip('Observe future array of parent with mapper function and use its proxy once it\'s available even if something else changes', t => {
   const { state, observe } = t.context.store
 
   const val1 = Math.random()

--- a/test/register.js
+++ b/test/register.js
@@ -323,7 +323,7 @@ test('Throws when observing primitive props', t => {
 
   $$register({ Component })
 
-  t.throws(() => new Component({ val: state.prop.value }))
+  t.throws(() => new Component({ val: state.prop.value }), /You are passing down/)
 })
 
 test('Throws when observing invalid type in mapStateToProps', t => {

--- a/test/register.js
+++ b/test/register.js
@@ -138,3 +138,28 @@ test.cb('Observers will not trigger handlers after component is disposed', t => 
   t.pass()
   t.end()
 })
+
+test.cb('Observe state change with mapState', t => {
+  const { $$register, state } = regie({ initialState: { prop: { value: null } } })
+
+  class Component {
+    constructor () {
+      this.created()
+    }
+
+    created () {
+      this.createdHooks()
+    }
+
+    ['mapState prop.value'] () {
+      t.end()
+    }
+
+    dispose () {}
+  }
+
+  $$register({ Component })
+  new Component()
+
+  state.prop.value = Math.random()
+})

--- a/test/register.js
+++ b/test/register.js
@@ -438,7 +438,7 @@ test.cb('Triggering a state change in action handler shouldn\'t trigger a new up
         }
       },
       actions: {
-        setScooterErrorModalDisconnected ({ mutations }) {
+        setUnrelatedState ({ mutations }) {
           mutations.setUnrelatedState('disconnected', { code: '324', key: 'fbz', someBoolean: true, title: 'foo', body: 'bar', cta: 'baz' })
         },
         setCounter ({ mutations }, operation) {
@@ -478,10 +478,10 @@ test.cb('Triggering a state change in action handler shouldn\'t trigger a new up
 
   $$register({ Component })
   new Component({ unrelatedState: state.unrelatedState })
-  actions.setScooterErrorModalDisconnected()
+  actions.setUnrelatedState()
 })
 
-test.cb('Props of children components should update to the appropriate value when those  props are overridden in the parent', t => {
+test.cb('Props of children components should update to the appropriate value when those props are overridden in the parent', t => {
   class FirstComponent {
     constructor (props) {
       this.props = props || {}
@@ -547,22 +547,22 @@ test.cb('Props of children components should update to the appropriate value whe
         setProp4 ({ mutations }) {
           mutations.setProp4('val3')
         },
-        setProp2 ({ mutations }, currentDestination) {
-          mutations.setProp2(currentDestination)
+        setProp2 ({ mutations }, val) {
+          mutations.setProp2(val)
         },
-        setProp3 ({ mutations }, currentScooter) {
-          mutations.setProp3(currentScooter)
+        setProp3 ({ mutations }, val) {
+          mutations.setProp3(val)
         }
       },
       mutations: {
         setProp4 ({ state }, value) {
           state.prop1.prop4 = value
         },
-        setProp2 ({ state }, currentDestination) {
-          state.prop2 = { prop5: currentDestination }
+        setProp2 ({ state }, val) {
+          state.prop2 = { prop5: val }
         },
-        setProp3 ({ state }, currentScooter) {
-          state.prop3 = currentScooter
+        setProp3 ({ state }, val) {
+          state.prop3 = val
         }
       }
     }, { deep: true })

--- a/test/register.js
+++ b/test/register.js
@@ -51,13 +51,13 @@ test.cb('Utilize existing __regie_changes__ getter on a component and observe st
 })
 
 test.cb('Utilize magic observer method on a component and observe state change', t => {
-  const { $$register, state } = regie({})
+  const { $$register, state } = regie({ initialState: { prop: { value: null } } })
 
   const val = Math.random()
 
   class Component {
-    constructor (state) {
-      this.props = state
+    constructor (props) {
+      this.props = props
 
       this.created()
     }
@@ -66,27 +66,26 @@ test.cb('Utilize magic observer method on a component and observe state change',
       this.createdHooks()
     }
 
-    ['observe val'] (newValue) {
-      t.is(newValue, val)
+    ['observe prop'] ({ value }) {
+      t.is(value, val)
       t.end()
     }
   }
 
   $$register({ Component })
-
   new Component(state)
 
-  state.val = val
+  state.prop = { value: val }
 })
 
 test('__regie_observer_removers__ exists on initialized component', t => {
-  const { $$register, state } = regie({})
+  const { $$register, state } = regie({ initialState: { prop: { value: null } } })
 
   const val = Math.random()
 
   class Component {
-    constructor (state) {
-      this.props = state
+    constructor (props) {
+      this.props = props
 
       this.created()
     }
@@ -95,8 +94,8 @@ test('__regie_observer_removers__ exists on initialized component', t => {
       this.createdHooks()
     }
 
-    ['observe val'] (newValue) {
-      t.is(newValue, val)
+    ['observe prop.value'] ({ value }) {
+      t.is(value, val)
       t.end()
     }
   }
@@ -109,11 +108,11 @@ test('__regie_observer_removers__ exists on initialized component', t => {
 })
 
 test.cb('Observers will not trigger handlers after component is disposed', t => {
-  const { $$register, state } = regie({})
+  const { $$register, state } = regie({ initialState: { prop: { value: null } } })
 
   class Component {
-    constructor (state) {
-      this.props = state
+    constructor (props) {
+      this.props = props
 
       this.created()
     }
@@ -122,7 +121,7 @@ test.cb('Observers will not trigger handlers after component is disposed', t => 
       this.createdHooks()
     }
 
-    ['observe val'] () {
+    ['observe prop.value'] () {
       t.fail()
     }
 
@@ -134,7 +133,7 @@ test.cb('Observers will not trigger handlers after component is disposed', t => 
   const comp = new Component(state)
   comp.dispose()
 
-  state.val = Math.random()
+  state.prop.value = Math.random()
 
   t.pass()
   t.end()

--- a/test/register.js
+++ b/test/register.js
@@ -327,7 +327,7 @@ test('Throws when observing primitive props', t => {
 })
 
 test('Throws when observing invalid type in mapStateToProps', t => {
-  const { $$register, state } = regie({ initialState: { prop: { value: null } } })
+  const { $$register } = regie({ initialState: { prop: { value: null } } })
 
   class Component {
     constructor (props) {

--- a/test/register.js
+++ b/test/register.js
@@ -588,3 +588,49 @@ test.cb('Props of children components should update to the appropriate value whe
     }
   })
 })
+
+test.cb('Observe deep array element changes', t => {
+  class Component {
+    constructor (props) {
+      this.props = props || {}
+      this.created()
+    }
+    created () {
+      this.createdHooks()
+    }
+    ['observe prop1.status'] (status, change) {
+      t.is(state.prop1.status[1].prop3.active, true)
+      t.end()
+    }
+    dispose () { }
+  }
+  const { $$register, actions, state } = regie(
+    {
+      initialState: {
+        prop1: {
+          status: [
+            { prop2: { active: false } },
+            { prop3: { active: false } }
+          ]
+        }
+      },
+      actions: {
+        setProp3 ({ mutations }, value) {
+          mutations.setProp3Active(value)
+        }
+      },
+      mutations: {
+        setProp3Active ({ state }, value) {
+          state.prop1.status[1].prop3.active = value
+        }
+      }
+    }, { deep: true })
+
+  $$register({ Component })
+
+  new Component({
+    prop1: state.prop1
+  })
+
+  actions.setProp3(true)
+})


### PR DESCRIPTION
This version is almost a complete rewrite and brings several new functionalities including more robust change tracking for future values and primitive values. It also fixes several of the bugs that exists in observing changes on deep nested objects with / without prior state.

Even though this is a major version, it's a backwards-compatible change, so should be a drop-in replacement for V1, which means the API is completely compatible with V1. The only change is a restriction for erste integration where one must explicitly have `initialState` in regie and use its properties as props when instantiating an erste `Component`. These props cannot be primitive values, which was allowed before.

This version also introduces `mapStateToProps` to erste integration so users don't have to explicitly pass in props from the state. `mapStateToProps` should be a method on the component that returns an object whose values are either path strings for variables or accessor functions. Both of the following examples achieve the same output:

```js
class Component {
  // ...
  mapStateToProps () {
    return {
      value: 'stateObject.value'
    }
  }

  ['observe value'] (newVal) {
    console.log(newVal)
  }
}
```
```js
class Component {
  // ...
  mapStateToProps () {
    return {
      value: state => state.stateObject.value
    }
  }

  ['observe value'] (newVal) {
    console.log(newVal)
  }
}
```